### PR TITLE
The space between projects section to contact section was to big, mt …

### DIFF
--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -58,7 +58,7 @@ const Contact = () => {
   };
 
   return (
-    <div className="xl:mt-12 xl:flex-row flex-col-reverse flex gap-10 overflow-hidden">
+    <div className="xl:flex-row flex-col-reverse flex gap-10 overflow-hidden">
       <motion.div
         variants={slideIn("left", "tween", 0.2, 1)}
         className="flex-[0.75] bg-black-100 p-8 rounded-2xl"

--- a/src/components/Works.jsx
+++ b/src/components/Works.jsx
@@ -90,4 +90,4 @@ const Works = () => {
   );
 };
 
-export default SectionWrapper(Works, "");
+export default SectionWrapper(Works, "work");


### PR DESCRIPTION
…was 12 on contact section I deleted it, i added to the works components export the string work so when i click on the work tab on the navbar it will take me to the work section."